### PR TITLE
Fix import path for standalone execution and robust editable install

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,18 @@
 
 This repository contains a small toolkit for processing 3GPP/QXDM log files. It extracts technical sentences from large archives and computes a range of metrics using sentence embeddings.
 
-The code has been refactored into the `ldp` Python package (located under `src/ldp`).
-Run the pipeline with:
+The code has been refactored into the `ldp` Python package (located under
+`src/ldp`).  When running directly from the repository without installing the
+package, ensure that the `src` directory is on your `PYTHONPATH`:
+
+```bash
+PYTHONPATH=src python -m ldp --help
+# or
+python src/ldp/main.py --help
+```
+
+If you install the project (for example with `pip install -e .`), the module can
+be invoked simply as:
 
 ```bash
 python -m ldp --help
@@ -23,18 +33,27 @@ python -m ldp --help
 pip install -r requirements.txt
 ```
 
-Optionally install the package in editable mode:
+Optionally install the package in editable mode, which also exposes the `ldp` console script:
 
 ```bash
 pip install -e .
+ldp --help  # verify the CLI is available
 ```
 
 ## Usage
 
-Run the pipeline with:
+From the repository root without installing the package:
 
 ```bash
-python -m ldp --help
+PYTHONPATH=src python -m ldp --help
+# or
+python src/ldp/main.py --help
+```
+
+After installation (`pip install -e .`) the command becomes:
+
+```bash
+python -m ldp --help  # or simply `ldp --help`
 ```
 
 Important environment variables:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,9 @@ dependencies = [
 
 [project.scripts]
 ldp = "ldp.main:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/ldp/main.py
+++ b/src/ldp/main.py
@@ -27,14 +27,26 @@ import torch
 import psutil
 from tqdm.auto import tqdm
 from sentence_transformers import SentenceTransformer
-from .metric_utils import (
+
+# When running ``main.py`` directly the package context is not initialised and
+# relative imports like ``from .metric_utils`` fail.  Detect this situation and
+# add the parent directory to ``sys.path`` so absolute imports work as well,
+# enabling both ``python -m ldp`` and ``python src/ldp/main.py`` for local
+# debugging.
+if __package__ is None or __package__ == "":  # pragma: no cover - runtime setup
+    import sys as _sys
+    from pathlib import Path as _Path
+
+    _sys.path.append(str(_Path(__file__).resolve().parent.parent))
+
+from ldp.metric_utils import (
     semantic_spread,
     redundancy_index,
     cluster_entropy,
     change_mag,
     novelty_density,
 )
-from .log_processor import QXDMLogProcessor
+from ldp.log_processor import QXDMLogProcessor
 
 try:
     import pynvml


### PR DESCRIPTION
## Summary
- allow `main.py` to run directly by setting up `sys.path` when package context is missing
- document how to run the pipeline without installing the package by adding `src` to `PYTHONPATH`
- configure setuptools to discover packages in `src` so `pip install -e .` reliably exposes the `ldp` CLI
- clarify editable-install instructions and how to verify the CLI works

## Testing
- `pip install -e .`
- `ldp --help`
- `python -m ldp --help`


------
https://chatgpt.com/codex/tasks/task_e_68900ba5c7a88328993265ede6fbcf1c